### PR TITLE
Adding user permissions requirements

### DIFF
--- a/ci-docs/connect-synapse.md
+++ b/ci-docs/connect-synapse.md
@@ -40,7 +40,7 @@ For more information, see [Azure Synapse overview](/azure/synapse-analytics/over
 
 - The *[Azure Synapse workspace managed identity](/azure/synapse-analytics/security/synapse-workspace-managed-identity)* needs **Storage Blob Data Contributor** permissions on the Azure Data Lake Storage Gen2 account where the data is located and linked to the Azure Synapse workspace. Learn more on [using the Azure portal to assign an Azure role for access to blob and queue data](/azure/storage/common/storage-auth-aad-rbac-portal) and [Storage Blob Data Contributor permissions](/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor).
 
-- On the Azure Synapse workspace, the *service principal for Customer Insights* which is "Dynamics 365 AI for Customer Insights" needs **Synapse Administrator** role assigned. For more information, see [How to set up access control for your Synapse workspace](/azure/synapse-analytics/security/how-to-set-up-access-control).
+- On the Azure Synapse workspace, the *service principal for Customer Insights* which is "Dynamics 365 AI for Customer Insights" needs **Synapse Administrator** role assigned. The **user** needs at least a **Synapse Contributor** role assigned for the workspace. For more information, see [How to set up access control for your Synapse workspace](/azure/synapse-analytics/security/how-to-set-up-access-control).
 
 - If your Customer Insights environment stores data in your [own Azure Data Lake Storage](own-data-lake-storage.md), the user who sets up the connection to Azure Synapse Analytics needs at least the built-in **Reader** role on the Data Lake Storage account. For more information, see [Assign Azure roles using the Azure portal](/azure/role-based-access-control/role-assignments-portal).
 


### PR DESCRIPTION
Without this permission, the user might get a permission error in the client when showing the attached storages to a Synapse workspace.