### PR TITLE
Clarify Portal (non)availability for RTM EM

### DIFF
--- a/ci-docs/journeys/event-management.md
+++ b/ci-docs/journeys/event-management.md
@@ -51,7 +51,7 @@ Customer Insights - Journeys contains a subset of outbound event management feat
 |     Tracking sponsors    |     [Yes](manage-event-sponsorships-outbound.md)    |     [Yes](manage-event-sponsorships.md)    |
 |     Creating Teams meetings/live events/webinars    |     [Yes](teams-webinar-outbound.md)    |     [Yes](teams-webinar.md)    |
 |     Support for On24 and other generic webinar providers      |     [Yes](set-up-webinar-outbound.md)    |     Planned    |
-|     Using marketing forms for registrations    |     [Yes](event-forms.md)    |     [Yes](real-time-marketing-form-create.md)   |
+|     Using marketing forms for registrations    |     [Yes](event-forms-outbound.md)    |     [Yes](real-time-marketing-form-create.md)   |
 |     Event Portal Landing Page    |    [Yes](set-up-event-portal-outbound.md)    |    Planned    |                     
 |     Waitlist    |     [Yes](event-waitlist-outbound.md)    |     Planned    |
 |     Payments    |     [Yes](event-payment-gateway-outbound.md)    |     Planned    |

--- a/ci-docs/journeys/event-management.md
+++ b/ci-docs/journeys/event-management.md
@@ -1,7 +1,7 @@
 ---
 title: Plan, publicize, and collect registrations for events
 description: An overview of event-management features (including planning, logistics, sponsors, speakers, promotion, and registration) in  Dynamics 365 Customer Insights - Journeys.
-ms.date: 12/15/2023
+ms.date: 12/21/2023
 ms.topic: article
 author: alfergus
 ms.author: alfergus
@@ -15,13 +15,13 @@ search.audienceType:
 
 [!INCLUDE [consolidated-sku-rtm-only](./includes/consolidated-sku-rtm-only.md)]
 
-Live events and webinars are a vital sales and marketing channel. But events and webinars can be complex to arrange, execute, and follow up on. The Dynamics 365 Customer Insights - Journeys event management feature helps you every step of the way, from initial planning and budgeting through promotion and publication, attendee registration, webinar broadcasting, final analytics, lead generation, and evaluation of ROI.
+Live events and webinars are vital sales and marketing channels. But events and webinars can be complex to arrange, execute, and follow up on. The Dynamics 365 Customer Insights - Journeys event management feature helps you every step of the way, from initial planning and budgeting through promotion and publication, attendee registration, webinar broadcasting, final analytics, lead generation, and evaluation of ROI.
 
 Key event-management features include:
 
 - Seamless contact, registration, and attendance management features in one system.
 - Business processes that guide users through the essential steps of event planning.
-- Session, session track, and speaker management.
+- Session, session tracking, and speaker management.
 - Managing attendee passes to grant access to specific sessions or tracks.
 - Venue management for tracking buildings, rooms, and room layouts.
 - Guest logistics for registering hotels, room allocation, and reservations.
@@ -52,7 +52,7 @@ Customer Insights - Journeys contains a subset of outbound event management feat
 |     Creating Teams meetings/live events/webinars    |     [Yes](teams-webinar-outbound.md)    |     [Yes](teams-webinar.md)    |
 |     Support for On24 and other generic webinar providers      |     [Yes](set-up-webinar-outbound.md)    |     Planned    |
 |     Using marketing forms for registrations    |     [Yes](event-forms-outbound.md)    |     [Yes](real-time-marketing-form-create.md)   |
-|     Event Portal Landing Page    |    [Yes](set-up-event-portal-outbound.md)    |    Planned    |                     
+|     Event portal landing page    |    [Yes](set-up-event-portal-outbound.md)    |    Planned    |                     
 |     Waitlist    |     [Yes](event-waitlist-outbound.md)    |     Planned    |
 |     Payments    |     [Yes](event-payment-gateway-outbound.md)    |     Planned    |
 |     Lead entity registration    |     [Yes](set-up-event-outbound.md#the-website-and-form-tab)    |     Planned    |

--- a/ci-docs/journeys/event-management.md
+++ b/ci-docs/journeys/event-management.md
@@ -52,6 +52,7 @@ Customer Insights - Journeys contains a subset of outbound event management feat
 |     Creating Teams meetings/live events/webinars    |     [Yes](teams-webinar-outbound.md)    |     [Yes](teams-webinar.md)    |
 |     Support for On24 and other generic webinar providers      |     [Yes](set-up-webinar-outbound.md)    |     Planned    |
 |     Using marketing forms for registrations    |     [Yes](event-forms.md)    |     [Yes](real-time-marketing-form-create.md)   |
+|     Event Portal Landing Page    |    [Yes](set-up-event-portal-outbound.md)    |    Planned    |                     
 |     Waitlist    |     [Yes](event-waitlist-outbound.md)    |     Planned    |
 |     Payments    |     [Yes](event-payment-gateway-outbound.md)    |     Planned    |
 |     Lead entity registration    |     [Yes](set-up-event-outbound.md#the-website-and-form-tab)    |     Planned    |

--- a/ci-docs/journeys/includes/consolidated-sku-rtm-only.md
+++ b/ci-docs/journeys/includes/consolidated-sku-rtm-only.md
@@ -2,3 +2,5 @@
 > Dynamics 365 Marketing and Dynamics 365 Customer Insights are now Customer Insights - Journeys and Customer Insights - Data. For more information, see [Dynamics 365 Customer Insights FAQs](/dynamics365/marketing/ci-faq)
 >
 > New Customer Insights - Journeys customers receive real-time journeys features only. For more information, see [Default real-time journeys installation](/dynamics365/marketing/real-time-marketing-move#default-customer-insights---journeys-installation).
+>
+> In Real-Time Marketing, the Event Portal Landing Page (Event Website) is currently not available. However, in the meantime, Marketing Forms for Registration can serve as a viable alternative to showcase event details and facilitate the registration process.

--- a/ci-docs/journeys/includes/consolidated-sku-rtm-only.md
+++ b/ci-docs/journeys/includes/consolidated-sku-rtm-only.md
@@ -2,5 +2,3 @@
 > Dynamics 365 Marketing and Dynamics 365 Customer Insights are now Customer Insights - Journeys and Customer Insights - Data. For more information, see [Dynamics 365 Customer Insights FAQs](/dynamics365/marketing/ci-faq)
 >
 > New Customer Insights - Journeys customers receive real-time journeys features only. For more information, see [Default real-time journeys installation](/dynamics365/marketing/real-time-marketing-move#default-customer-insights---journeys-installation).
->
-> In Real-Time Marketing, the Event Portal Landing Page (Event Website) is currently not available. However, in the meantime, [Marketing Forms](../real-time-marketing-form-create.md) for Registration can serve as a viable alternative to showcase event details and facilitate the registration process.

--- a/ci-docs/journeys/includes/consolidated-sku-rtm-only.md
+++ b/ci-docs/journeys/includes/consolidated-sku-rtm-only.md
@@ -3,4 +3,4 @@
 >
 > New Customer Insights - Journeys customers receive real-time journeys features only. For more information, see [Default real-time journeys installation](/dynamics365/marketing/real-time-marketing-move#default-customer-insights---journeys-installation).
 >
-> In Real-Time Marketing, the Event Portal Landing Page (Event Website) is currently not available. However, in the meantime, Marketing Forms for Registration can serve as a viable alternative to showcase event details and facilitate the registration process.
+> In Real-Time Marketing, the Event Portal Landing Page (Event Website) is currently not available. However, in the meantime, [Marketing Forms](../real-time-marketing-form-create.md) for Registration can serve as a viable alternative to showcase event details and facilitate the registration process.


### PR DESCRIPTION
We have been getting various SRs around this lately: Customer is expecting the portals to be usable (such as in OBM Event website) in RTM events as well. Adding information for relevant document as further clarification.

https://learn.microsoft.com/en-us/dynamics365/customer-insights/journeys/event-management