### PR TITLE
Clarify deduplication of registrations (not possible)

### DIFF
--- a/ci-docs/journeys/events-settings.md
+++ b/ci-docs/journeys/events-settings.md
@@ -117,6 +117,9 @@ To set your event-administration options:
     > To make the name-based contact matching strategy work with **Portal Authentication** it is mandatory to provide first and last name after registering.
 
     > [!NOTE]
+    > It not possible to deduplicate registrations for the same contact in out-of-box marketing events: A new registration would be created for the same contact that registered to the same event.
+
+    > [!NOTE]
     > The email templates provided for sending confirmations to the event purchaser and/or attendee are hard coded, so you can't customize or translate their content. If you require custom messaging, then set up a [customer journey](customer-journeys-create-automated-campaigns.md) with event, trigger, and email tiles.
 
 ## Website table configurations

--- a/ci-docs/journeys/events-settings.md
+++ b/ci-docs/journeys/events-settings.md
@@ -1,7 +1,7 @@
 ---
 title: Set up event administration options and webinar provider accounts in outbound marketing
 description: Set options for event administration and configure connections to your webinar provider accounts in outbound marketing.
-ms.date: 08/18/2023
+ms.date: 01/03/2024
 ms.topic: article
 author: alfergus
 ms.author: alfergus
@@ -117,10 +117,10 @@ To set your event-administration options:
     > To make the name-based contact matching strategy work with **Portal Authentication** it is mandatory to provide first and last name after registering.
 
     > [!NOTE]
-    > It not possible to deduplicate registrations for the same contact in out-of-box marketing events: A new registration would be created for the same contact that registered to the same event.
+    > It's not possible to deduplicate registrations for the same contact for out-of-the-box marketing events. When duplicate registrations are made for the same contact, a new registration is created for the contact.
 
     > [!NOTE]
-    > The email templates provided for sending confirmations to the event purchaser and/or attendee are hard coded, so you can't customize or translate their content. If you require custom messaging, then set up a [customer journey](customer-journeys-create-automated-campaigns.md) with event, trigger, and email tiles.
+    > The email templates provided for sending confirmations to the event purchaser and/or attendee are hard-coded, so you can't customize or translate their content. If you require custom messaging, then set up a [customer journey](customer-journeys-create-automated-campaigns.md) with event, trigger, and email tiles.
 
 ## Website table configurations
 


### PR DESCRIPTION
We have been getting SRs around why new registrations are being created for the same contact on the same event. This is by-design behavior.

Related task: https://dev.azure.com/dynamicscrm/CXPlatform/_workitems/edit/3751155