### PR TITLE
Update RTM SMS Consent

### DIFF
--- a/ci-docs/journeys/real-time-marketing-email-text-consent.md
+++ b/ci-docs/journeys/real-time-marketing-email-text-consent.md
@@ -90,7 +90,7 @@ The following diagram provides a visual representation of how consent is checked
   <tr>
    <td><b>SMS/custom channel</b></td>
     <td>Blocked</td>
-    <td>Sent</td>
+    <td>Blocked</td>
     <td>Sent</td>
   </tr>
   <tr>


### PR DESCRIPTION
As per the documentation: A user must always opt in to consent to receive commercial SMS or commercial custom channel messages. By default the transactional SMS and custom channel messages are always sent, unless you change the enforcement model from disabled.

Shouldn't then the SMS be blocked when the  Restrictive Enforcement Model is set to Restrictive enforcement model ?